### PR TITLE
Change Linux library name to the Windows one

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1294,8 +1294,9 @@ elseif(UNIX)
   # set the version in the filename, and create the symlink at install
   # time.  Note: could be dropped when the SONAME is updated and
   # libtool compatibility is no longer required.
+  # [Leica] change filename which is same as Windows
   if(BUILD_SHARED_LIBS)
-    set_target_properties(xerces-c PROPERTIES OUTPUT_NAME "xerces-c-${INTERFACE_VERSION_D}")
+    set_target_properties(xerces-c PROPERTIES OUTPUT_NAME "xerces-c_${INTERFACE_VERSION_U}")
     file(GENERATE
       OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/InstallLibrarySymlink.cmake"
       CONTENT "execute_process(COMMAND ln -sf \"$<TARGET_FILE_NAME:xerces-c>\" \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_LIBDIR}/libxerces-c${CMAKE_SHARED_LIBRARY_SUFFIX}\")")


### PR DESCRIPTION
Captivate expects the same library name on both Linux and Windows